### PR TITLE
TINY-11552: Fix type alias

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,8 @@
 #!groovy
 @Library('waluigi@release/7') _
 
-beehiveFlowBuild()
-
+beehiveFlowBuild(
+  container: [
+    tag: '20',
+  ]
+)

--- a/src/main/ts/api/Pprint.ts
+++ b/src/main/ts/api/Pprint.ts
@@ -1,12 +1,11 @@
 import * as Show from './Show';
+import { type Show as ShowType } from './Show';
 import * as ArrayUtil from '../core/ArrayUtil';
 import * as ObjectUtil from '../core/ObjectUtil';
 import * as StringUtil from '../core/StringUtil';
 import * as Type from '../core/Type';
 import * as Pnode from './Pnode';
-
-type PnodeType = Pnode.Pnode;
-type ShowType<A> = Show.Show<A>;
+import { type Pnode as PnodeType } from './Pnode';
 
 export interface Pprint<A> {
   pprint: (a: A) => PnodeType;

--- a/src/main/ts/api/Pprint.ts
+++ b/src/main/ts/api/Pprint.ts
@@ -5,21 +5,21 @@ import * as StringUtil from '../core/StringUtil';
 import * as Type from '../core/Type';
 import * as Pnode from './Pnode';
 
-type Pnode = Pnode.Pnode;
-type Show<A> = Show.Show<A>;
+type PnodeType = Pnode.Pnode;
+type ShowType<A> = Show.Show<A>;
 
 export interface Pprint<A> {
-  pprint: (a: A) => Pnode;
+  pprint: (a: A) => PnodeType;
 }
 
-export const pprint = <A> (f: (a: A) => Pnode): Pprint<A> => ({ pprint: f });
+export const pprint = <A> (f: (a: A) => PnodeType): Pprint<A> => ({ pprint: f });
 
 export const render = <A> (a: A, pp: Pprint<A>): string => {
   const n = pp.pprint(a);
   return Pnode.render(n);
 };
 
-export const pprintShow = <A> (show: Show<A>): Pprint<A> =>
+export const pprintShow = <A> (show: ShowType<A>): Pprint<A> =>
   pprint((a) => Pnode.single(show.show(a)));
 
 export const pprintUndefined: Pprint<undefined> = pprintShow(Show.showUndefined);
@@ -39,7 +39,7 @@ export const pprintArray = <A> (pprintA: Pprint<A>): Pprint<ArrayLike<A>> => ppr
 export const pprintRecord = <A> (pprintA: Pprint<A>): Pprint<Record<string, A>> => pprint((r) => {
   const tuples = ObjectUtil.toTuples(r);
 
-  const cnode: (t: [string, A]) => Pnode = ([ k, v ]) => {
+  const cnode: (t: [string, A]) => PnodeType = ([ k, v ]) => {
     const pv = pprintA.pprint(v);
     const start = StringUtil.doubleQuote(k) + ': ';
     return Pnode.prependStart(start)(pv);


### PR DESCRIPTION
Related Ticket:  TINY-11552

Description of Changes:
* Getting error when running `"rollup:core-types" (rollup) task` post upgrading `rollup-plugin-dts` to 6.1.1 (which is part of upgrading rollup to v4), which is due to: https://github.com/Swatinem/rollup-plugin-dts/blob/master/CHANGELOG.md#600
```
Running "rollup:core-types" (rollup) task
Warning: ../../node_modules/@ephox/dispute/lib/main/ts/api/Pprint.d.ts (3:0): Identifier "Pnode" has already been declared Use --force to continue.
```


Pre-checks:
* [x] Changelog entry added
* [x] package.json version bumped (if first change of new major/minor)
* [x] Tests have been added (if applicable)
